### PR TITLE
Add 'status' command

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -121,6 +121,7 @@ dotnet biak setup
 ```
 dotnet biak enable
 dotnet biak disable
+dotnet biak status
 ```
 
 That's it - biak is configured. Happy coding! 🚀

--- a/docs/wiki/Status.md
+++ b/docs/wiki/Status.md
@@ -1,0 +1,23 @@
+# Status
+
+The `dotnet biak status` command returns the current Biak mode for the root `.editorconfig`.
+
+## Usage
+
+```bash
+dotnet biak status
+```
+
+## Output
+
+```bash
+on
+```
+
+`on` means the current `.editorconfig` matches the enabled Biak configuration.
+
+```bash
+off
+```
+
+`off` means the current `.editorconfig` does not match the enabled Biak configuration, for example after `dotnet biak disable`.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -2,6 +2,7 @@
 * [Setup](Setup)
 * [Enable](Enable)
 * [Disable](Disable)
+* [Status](Status)
 * [Config](Config)
 * [GitHub Actions](EnableDisableGitHubAction)
 

--- a/src/Biak.ConsoleApp/Biak.ConsoleApp.csproj
+++ b/src/Biak.ConsoleApp/Biak.ConsoleApp.csproj
@@ -10,7 +10,7 @@
     <NoWarn>NETSDK1138</NoWarn>
     <EnablePackageValidation>true</EnablePackageValidation>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>0.6.2</Version>
+    <Version>0.6.1</Version>
     <PackageId>kurnakovv.biak</PackageId>
     <Authors>kurnakovv</Authors>
     <Company>kurnakovv</Company>

--- a/src/Biak.ConsoleApp/Biak.ConsoleApp.csproj
+++ b/src/Biak.ConsoleApp/Biak.ConsoleApp.csproj
@@ -10,7 +10,7 @@
     <NoWarn>NETSDK1138</NoWarn>
     <EnablePackageValidation>true</EnablePackageValidation>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>0.6.1</Version>
+    <Version>0.6.2</Version>
     <PackageId>kurnakovv.biak</PackageId>
     <Authors>kurnakovv</Authors>
     <Company>kurnakovv</Company>

--- a/src/Biak.ConsoleApp/Commands/StatusCommand.cs
+++ b/src/Biak.ConsoleApp/Commands/StatusCommand.cs
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 kurnakovv
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+using Biak.ConsoleApp.Constants;
+using Biak.ConsoleApp.Helpers;
+using Biak.ConsoleApp.Models;
+
+namespace Biak.ConsoleApp.Commands;
+
+/// <summary>
+/// `dotnet biak status` command.
+/// </summary>
+public static class StatusCommand
+{
+    /// <summary>
+    /// Can `dotnet biak status` command be run.
+    /// </summary>
+    /// <param name="args">User input arguments.</param>
+    /// <returns>Can be run or not.</returns>
+    public static bool IsRunnable(string[] args)
+    {
+        return args.Length == 1 && args[0] == CommandArgumentConstant.STATUS;
+    }
+
+    /// <summary>
+    /// Run.
+    /// </summary>
+    /// <returns><placeholder>A <see cref="Task"/> representing the asynchronous operation.</placeholder></returns>
+    public static async Task RunAsync()
+    {
+        EditorconfigPaths editorconfigPaths = SetupHelper.GetEditorconfigPaths();
+
+        if (editorconfigPaths.MainValue == null || editorconfigPaths.Value == null)
+        {
+            return;
+        }
+
+        (_, BiakConfig config) = await BiakConfigHelper.GetAsync();
+
+        string currentContent = await File.ReadAllTextAsync(editorconfigPaths.Value);
+        string enabledContent = await GetEnabledContentAsync(editorconfigPaths.MainValue, config);
+
+        Console.WriteLine(
+            string.Equals(
+                NormalizeLineEndings(currentContent),
+                NormalizeLineEndings(enabledContent),
+                StringComparison.Ordinal
+            )
+                ? UIConstant.STATUS_ON
+                : UIConstant.STATUS_OFF
+        );
+    }
+
+    private static async Task<string> GetEnabledContentAsync(string editorconfigMainPath, BiakConfig config)
+    {
+        string content = await File.ReadAllTextAsync(editorconfigMainPath);
+        content = await ImportHelper.ReplaceAsync(content, config.OnImportFailure);
+        content = IncludeExcludeFilterHelper.Apply(content);
+        content = VariableHelper.Substitute(content);
+        return EditorconfigHelper.AddAttentionBanners(content);
+    }
+
+    private static string NormalizeLineEndings(string content)
+    {
+        return content
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace("\r", "\n", StringComparison.Ordinal);
+    }
+}

--- a/src/Biak.ConsoleApp/Constants/CommandArgumentConstant.cs
+++ b/src/Biak.ConsoleApp/Constants/CommandArgumentConstant.cs
@@ -40,6 +40,11 @@ public static class CommandArgumentConstant
     public const string DISABLE = "disable";
 
     /// <summary>
+    /// Get current .editorconfig rules status.
+    /// </summary>
+    public const string STATUS = "status";
+
+    /// <summary>
     /// Find active branches with files.
     /// </summary>
     public const string FIND_ACTIVITY = "find-activity";

--- a/src/Biak.ConsoleApp/Constants/DocsConstant.cs
+++ b/src/Biak.ConsoleApp/Constants/DocsConstant.cs
@@ -77,6 +77,8 @@ Enable / Disable .editorconfig rules | Change severity level with one command wi
 
 * dotnet biak disable | The disable command takes the contents of editorconfig-main, disables all rules (error|warning|suggestion -> none) and inserts them into .editorconfig https://github.com/kurnakovv/biak/wiki/Disable
 
+* dotnet biak status | The status command returns on when Biak rules are currently enabled, otherwise off https://github.com/kurnakovv/biak/wiki/Status
+
 * Config (no command) | Configure biak behavior via the .biak/config.json file https://github.com/kurnakovv/biak/wiki/Config
 --------------------
 Find activity / conflicts | Features for finding active and conflicting files and generating filters for .editorconfig file. This is especially useful for legacy projects with many rule violations, allowing gradual integration without major conflicts.

--- a/src/Biak.ConsoleApp/Constants/UIConstant.cs
+++ b/src/Biak.ConsoleApp/Constants/UIConstant.cs
@@ -68,4 +68,14 @@ public static class UIConstant
     /// End enable message.
     /// </summary>
     public const string END_ENABLE = ".editorconfig has been restored from backup (.biak/.editorconfig-main).";
+
+    /// <summary>
+    /// Enabled status output.
+    /// </summary>
+    public const string STATUS_ON = "on";
+
+    /// <summary>
+    /// Disabled status output.
+    /// </summary>
+    public const string STATUS_OFF = "off";
 }

--- a/src/Biak.ConsoleApp/Program.cs
+++ b/src/Biak.ConsoleApp/Program.cs
@@ -39,6 +39,10 @@ public static class Program
         {
             await EnableCommand.RunAsync();
         }
+        else if (StatusCommand.IsRunnable(args))
+        {
+            await StatusCommand.RunAsync();
+        }
         else if (FindActivityCommand.IsRunnable(args))
         {
             await FindActivityCommand.RunAsync();

--- a/tests/Biak.ConsoleApp.IntegrationTests/Commands/StatusCommandTests.cs
+++ b/tests/Biak.ConsoleApp.IntegrationTests/Commands/StatusCommandTests.cs
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 kurnakovv
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+using Biak.ConsoleApp.Commands;
+using Biak.ConsoleApp.Constants;
+using Biak.ConsoleApp.IntegrationTests.Mock;
+
+namespace Biak.ConsoleApp.IntegrationTests.Commands;
+
+public class StatusCommandTests
+{
+    [Fact]
+    public async Task RunWithoutBiakFolderAsync()
+    {
+        TextWriter originalOut = Console.Out;
+        await using StringWriter output = new();
+        Console.SetOut(output);
+
+        try
+        {
+            await StatusCommand.RunAsync();
+
+            string result = output.ToString();
+            Assert.Contains(UIConstant.BIAK_NOT_INITIALIZED, result, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(UIConstant.RUN_BIAK_SETUP, result, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public async Task RunWithoutEditorconfigFileAsync()
+    {
+        string originalDirectory = Directory.GetCurrentDirectory();
+        TestDirectory testDir = new($"{nameof(StatusCommandTests)}_{nameof(RunWithoutEditorconfigFileAsync)}");
+
+        string biakDir = Path.Join(testDir.Value, ".biak");
+        Directory.CreateDirectory(biakDir);
+        string templateEditorconfigMain = Path.Join(
+            AppContext.BaseDirectory,
+            "Templates",
+            "Disabled",
+            ".biak",
+            ".editorconfig-main"
+        );
+
+        File.Copy(
+            sourceFileName: templateEditorconfigMain,
+            destFileName: Path.Join(biakDir, ".editorconfig-main"),
+            overwrite: true
+        );
+
+        try
+        {
+            Directory.SetCurrentDirectory(testDir.Value);
+
+            TextWriter originalOut = Console.Out;
+            await using StringWriter output = new();
+            Console.SetOut(output);
+
+            try
+            {
+                await StatusCommand.RunAsync();
+
+                string result = output.ToString();
+                Assert.Contains(UIConstant.EDITORCONFIG_NOT_FOUND, result, StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDirectory);
+        }
+    }
+
+    [Theory]
+    [InlineData(true, UIConstant.STATUS_ON)]
+    [InlineData(false, UIConstant.STATUS_OFF)]
+    public async Task RunWithEditorconfigAsync(bool enabled, string expectedStatus)
+    {
+        string originalDirectory = Directory.GetCurrentDirectory();
+        TestDirectory testDir = new($"{nameof(StatusCommandTests)}_{nameof(RunWithEditorconfigAsync)}_{expectedStatus}");
+
+        string biakDir = Path.Join(testDir.Value, ".biak");
+        Directory.CreateDirectory(biakDir);
+
+        string biakCategoriesDir = Path.Join(testDir.Value, ".biak", "Categories");
+        Directory.CreateDirectory(biakCategoriesDir);
+
+        string templateEditorconfig = Path.Join(
+            AppContext.BaseDirectory,
+            "Templates",
+            ".editorconfig"
+        );
+        testDir.CopyTemplateEditorconfig(templateEditorconfig);
+
+        string templateEditorconfigMain = Path.Join(
+            AppContext.BaseDirectory,
+            "Templates",
+            "Disabled",
+            ".biak",
+            ".editorconfig-main"
+        );
+
+        File.Copy(
+            sourceFileName: templateEditorconfigMain,
+            destFileName: Path.Join(biakDir, ".editorconfig-main"),
+            overwrite: true
+        );
+
+        string templateEditorconfigRoslynator = Path.Join(
+            AppContext.BaseDirectory,
+            "Templates",
+            "Import",
+            ".biak",
+            "Categories",
+            ".editorconfig-Roslynator"
+        );
+
+        File.Copy(
+            sourceFileName: templateEditorconfigRoslynator,
+            destFileName: Path.Join(biakCategoriesDir, ".editorconfig-Roslynator"),
+            overwrite: true
+        );
+
+        string templateEditorconfigStyleCop = Path.Join(
+            AppContext.BaseDirectory,
+            "Templates",
+            "Import",
+            ".biak",
+            "Categories",
+            ".editorconfig-StyleCop"
+        );
+
+        File.Copy(
+            sourceFileName: templateEditorconfigStyleCop,
+            destFileName: Path.Join(biakCategoriesDir, ".editorconfig-StyleCop"),
+            overwrite: true
+        );
+
+        try
+        {
+            Directory.SetCurrentDirectory(testDir.Value);
+
+            TextWriter originalOut = Console.Out;
+            await using StringWriter output = new();
+            Console.SetOut(output);
+
+            try
+            {
+                if (enabled)
+                {
+                    await EnableCommand.RunAsync();
+                }
+                else
+                {
+                    await DisableCommand.RunAsync();
+                }
+
+                output.GetStringBuilder().Clear();
+
+                await StatusCommand.RunAsync();
+
+                string result = output.ToString().Trim();
+                Assert.Equal(expectedStatus, result);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDirectory);
+        }
+    }
+}

--- a/tests/Biak.ConsoleApp.UnitTests/Commands/StatusCommandTests.cs
+++ b/tests/Biak.ConsoleApp.UnitTests/Commands/StatusCommandTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 kurnakovv
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+using Biak.ConsoleApp.Commands;
+using Biak.ConsoleApp.Constants;
+
+namespace Biak.ConsoleApp.UnitTests.Commands;
+
+public class StatusCommandTests
+{
+    [Fact]
+    public void IsRunnableFalseForEmptyParams()
+    {
+        Assert.False(StatusCommand.IsRunnable([]), "You can't run status command without `status` argument");
+    }
+
+    [Fact]
+    public void IsRunnableFalseForInvalidParams()
+    {
+        Assert.False(StatusCommand.IsRunnable(["blabla"]), "`blabla` is invalid param");
+        Assert.False(StatusCommand.IsRunnable([CommandArgumentConstant.STATUS, "invalid"]), "`status` + `invalid` is invalid");
+        Assert.False(StatusCommand.IsRunnable(["invalid", CommandArgumentConstant.STATUS]), "`invalid` + `status` is invalid");
+        Assert.False(StatusCommand.IsRunnable([CommandArgumentConstant.SETUP]), "`setup` is invalid");
+    }
+
+    [Fact]
+    public void IsRunnableTrueForSingleStatusParam()
+    {
+        Assert.True(StatusCommand.IsRunnable([CommandArgumentConstant.STATUS]));
+    }
+}


### PR DESCRIPTION
The main purpose of these changes is to provide the necessary handles for creating a Visual Studio editor UI button that displays the current BIAK status and allows users to toggle it with a click. This eliminates the need to use the CLI in Visual Studio and streamlines the development process.


PR introduces the `dotnet biak status` command that compares the current .editorconfig with the enabled Biak configuration and prints `on` or `off`. Implements StatusCommand with content normalization and enabled-content resolution (imports, filters, variables, banners). Wires the command into Program, adds UI and argument constants, and documents the command (docs/wiki/Status.md and sidebar). Adds unit and integration tests for the command.



